### PR TITLE
414 status code message corrected

### DIFF
--- a/src/daemon/reason_phrase.c
+++ b/src/daemon/reason_phrase.c
@@ -76,7 +76,7 @@ static const char *four_hundred[] = {
   "Length Required",
   "Precondition Failed",
   "Request Entity Too Large",
-  "Request-URI Too Large",
+  "Request-URI Too Long",
   "Unsupported Media Type",
   "Requested Range Not Satisfiable",
   "Expectation Failed",


### PR DESCRIPTION
According to the RFC7231, section 6.5.12, the message should be "Request-URI Too Long"
